### PR TITLE
Github APIにfetchする処理にエラーハンドリング等をつけた

### DIFF
--- a/backend/app/services/github_service.rb
+++ b/backend/app/services/github_service.rb
@@ -69,5 +69,23 @@ class GithubService
     end
 
     days
+
+  rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
+    Rails.logger.error(
+      "[GithubService] Network error: #{e.class} #{e.message}"
+    )
+    []
+
+  rescue JSON::ParserError => e
+    Rails.logger.error(
+      "[GithubService] JSON parse error: #{e.message}"
+    )
+    []
+
+  rescue StandardError => e
+    Rails.logger.error(
+      "[GithubService] Unexpected error: #{e.class} #{e.message}"
+    )
+    []
   end
 end


### PR DESCRIPTION
エラーハンドリング動作確認はspecを書いたときにでも
とりあえずfetch動作はしている